### PR TITLE
Add catch trap for Apple Silicon CPUs to make it compile on M1 Apple computers

### DIFF
--- a/src/single_include/catch.hpp
+++ b/src/single_include/catch.hpp
@@ -2129,8 +2129,10 @@ namespace Catch{
         #define CATCH_TRAP() \
                 __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
                 : : : "memory","r0","r3","r4" ) /* NOLINT */
-    #else
+    #elif defined(__x86_64__)
         #define CATCH_TRAP() __asm__("int $3\n" : : /* NOLINT */ )
+    #elif defined(__aarch64__)
+        #define CATCH_TRAP()  __asm__(".inst 0xd4200000") /* NOLINT */
     #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)


### PR DESCRIPTION
What the title says, I have added an ARM compatible catch trap so I can use NJOY on ARM based Macbook.